### PR TITLE
Fix asset path and popup markup

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -41,7 +41,8 @@ module.exports = {
       {
         test: /\.(woff2?|ttf|eot|svg)$/,
         type: 'asset/resource',
-        generator: { filename: 'katex/0.16.10/[name][ext]' }
+        // keep path version in sync with package.json katex dependency
+        generator: { filename: 'katex/0.16.22/[name][ext]' }
       }
     ]
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,11 @@
 <!doctype html>
-<meta charset="utf-8" />
-<title>WebTeX</title>
-<link rel="stylesheet" href="popup.css" />
-
-<body>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WebTeX</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
   <header>
     <img src="icons/icon_48.png" alt="WebTeX icon" />
     <h2>WebTeX</h2>
@@ -34,4 +36,5 @@
   </nav>
 
   <script type="module" src="popup.js"></script>
-</body>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -33,7 +33,7 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "katex/0.16.10/*",
+        "katex/0.16.22/*",
         "app.css"
       ],
       "matches": ["<all_urls>"]


### PR DESCRIPTION
## Summary
- update KaTeX asset path to version 0.16.22
- correct popup HTML structure with `<html>` and `<head>` tags

## Testing
- `npm run build` *(fails: Cannot find module 'webpack', because dependencies are not installed)*