### PR TITLE
Fix asset path and popup markup

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -41,7 +41,8 @@ module.exports = {
       {
         test: /\.(woff2?|ttf|eot|svg)$/,
         type: 'asset/resource',
-        generator: { filename: 'katex/0.16.10/[name][ext]' }
+        // keep path version in sync with package.json katex dependency
+        generator: { filename: 'katex/0.16.22/[name][ext]' }
       }
     ]
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,9 +1,11 @@
 <!doctype html>
-<meta charset="utf-8" />
-<title>WebTeX</title>
-<link rel="stylesheet" href="popup.css" />
-
-<body>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WebTeX</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
   <header>
     <img src="icons/icon_48.png" alt="WebTeX icon" />
     <h2>WebTeX</h2>
@@ -34,4 +36,5 @@
   </nav>
 
   <script type="module" src="popup.js"></script>
-</body>
+  </body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -33,7 +33,7 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "katex/0.16.10/*",
+        "katex/0.16.22/*",
         "app.css"
       ],
       "matches": ["<all_urls>"]

--- a/src/app.js
+++ b/src/app.js
@@ -25,10 +25,13 @@ const DELIMITERS = [
     /* ① If mutations are only UI ripples → ignore ---------------- */
     if (mutationsOnlyRipple(muts)) return;          // ★ new guard
 
-    /* ② If user is typing in an active editor → ignore ----------- */
+    /* ② If user is selecting text → ignore ----------------------- */
+    if (userIsSelectingText()) return;              // ★ new guard
+
+    /* ③ If user is typing in an active editor → ignore ----------- */
     if (typingInsideActiveElement(muts)) return;    // ★ new guard
 
-    /* ③ Otherwise, re‑render only the nodes that were added ------ */
+    /* ④ Otherwise, re‑render only the nodes that were added ------ */
     muts.flatMap(m => [...m.addedNodes])
         .filter(n => n.nodeType === 1)
         .forEach(safeRender);
@@ -68,6 +71,12 @@ function typingInsideActiveElement (muts) {         // ★ new
   const active = document.activeElement;
   if (!active || !nodeIsEditable(active)) return false;
   return muts.every(m => active.contains(m.target));
+}
+
+/* True if the user currently has text selected -------------------- */
+function userIsSelectingText () {
+  const sel = document.getSelection();
+  return sel && sel.rangeCount > 0 && !sel.isCollapsed;
 }
 
 /* Ignore Angular / MDC hover‑ripples to avoid re‑renders ------------ */


### PR DESCRIPTION
## Summary
- update KaTeX asset path to version 0.16.22
- correct popup HTML structure with `<html>` and `<head>` tags
- skip rerender while text is selected to preserve cursor/selection

## Testing
- `npm run build`